### PR TITLE
pre-approval url updates

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
@@ -197,13 +197,15 @@ module ActiveMerchant #:nodoc:
           x.requestEnvelope do |x|
             x.detailLevel 'ReturnAll'
             x.errorLanguage opts[:error_language] ||= 'en_US'
-            x.senderEmail opts[:senderEmail]
+            x.senderEmail opts[:senderEmail] if opts.has_key?[:senderEmail]
           end
 
           # required preapproval fields
           x.endingDate opts[:end_date].strftime("%Y-%m-%dT%H:%M:%S")
           x.startingDate opts[:start_date].strftime("%Y-%m-%dT%H:%M:%S")
           x.maxTotalAmountOfAllPayments opts[:max_amount]
+          x.maxAmountPerPayment opts[:maxAmountPerPayment] if opts.has_key?[:maxAmountPerPayment]
+          x.memo opts[:memo] if opts.has_key?[:memo]
           x.maxNumberOfPayments opts[:maxNumberOfPayments] if
             opts.has_key?(:maxNumberOfPayments)
           x.currencyCode options[:currency_code]

--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
@@ -28,6 +28,7 @@ module ActiveMerchant #:nodoc:
       end
 
 	    self.test_redirect_url= "https://www.sandbox.paypal.com/webscr?cmd=_ap-payment&paykey="
+      self.test_redirect_pre_approval_url= "https://www.sandbox.paypal.com/webscr?cmd=_ap-preapproval&preapprovalkey="
       self.supported_countries = ['US']
       self.homepage_url = 'http://x.com/'
       self.display_name = 'Paypal Adaptive Payments'
@@ -197,15 +198,15 @@ module ActiveMerchant #:nodoc:
           x.requestEnvelope do |x|
             x.detailLevel 'ReturnAll'
             x.errorLanguage opts[:error_language] ||= 'en_US'
-            x.senderEmail opts[:senderEmail] if opts.has_key?[:senderEmail]
+            x.senderEmail opts[:senderEmail] if opts.has_key?(:senderEmail)
           end
 
           # required preapproval fields
           x.endingDate opts[:end_date].strftime("%Y-%m-%dT%H:%M:%S")
           x.startingDate opts[:start_date].strftime("%Y-%m-%dT%H:%M:%S")
           x.maxTotalAmountOfAllPayments opts[:max_amount]
-          x.maxAmountPerPayment opts[:maxAmountPerPayment] if opts.has_key?[:maxAmountPerPayment]
-          x.memo opts[:memo] if opts.has_key?[:memo]
+          x.maxAmountPerPayment opts[:maxAmountPerPayment] if opts.has_key?(:maxAmountPerPayment)
+          x.memo opts[:memo] if opts.has_key?(:memo)
           x.maxNumberOfPayments opts[:maxNumberOfPayments] if
             opts.has_key?(:maxNumberOfPayments)
           x.currencyCode options[:currency_code]

--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
@@ -90,11 +90,8 @@ module ActiveMerchant #:nodoc:
             x.errorLanguage opts[:error_language] ||= 'en_US'
           end
           x.actionType 'PAY'
-          puts "**************"  if opts.key?(:preapproval_key)
-          puts opts[:preapproval_key] if opts.key?(:preapproval_key)
-          puts "**************"  if opts.key?(:preapproval_key)
-          x.senderEmail opts[:sender_email] if
-            opts.key?(:sender_email)
+          x.preapprovalKey opts[:preapproval_key] if opts.key?(:preapproval_key)
+          x.senderEmail opts[:sender_email] if opts.key?(:sender_email)
           x.cancelUrl opts[:cancel_url]
           x.returnUrl opts[:return_url]
           x.ipnNotificationUrl opts[:ipn_notification_url] if

--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
@@ -90,6 +90,9 @@ module ActiveMerchant #:nodoc:
             x.errorLanguage opts[:error_language] ||= 'en_US'
           end
           x.actionType 'PAY'
+          puts "**************"  if opts.key?(:preapproval_key)
+          puts opts[:preapproval_key] if opts.key?(:preapproval_key)
+          puts "**************"  if opts.key?(:preapproval_key)
           x.senderEmail opts[:sender_email] if
             opts.key?(:sender_email)
           x.cancelUrl opts[:cancel_url]

--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payment_common.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payment_common.rb
@@ -4,7 +4,10 @@ module ActiveMerchant
       def self.included(base)
         base.cattr_accessor :test_redirect_url
         base.cattr_accessor :live_redirect_url
+        base.cattr_accessor :test_redirect_pre_approval_url
+        base.cattr_accessor :live_redirect_pre_approval_url
         base.live_redirect_url = 'https://www.paypal.com/webscr?cmd=_ap-payment&paykey='
+        base.live_redirect_pre_approval_url = 'https://www.paypal.com/webscr?cmd=_ap-preapproval&preapprovalkey='
       end
 
       def redirect_url
@@ -14,6 +17,15 @@ module ActiveMerchant
       def redirect_url_for(token)
         redirect_url + token
       end
+
+      def redirect_pre_approval_url
+        test? ? test_redirect_pre_approval_url : live_redirect_pre_approval_url
+      end
+
+      def redirect_pre_approval_url_for(token)
+        redirect_pre_approval_url + token
+      end
+
     end
   end
 end

--- a/test/test_paypal_adaptive_payment.rb
+++ b/test/test_paypal_adaptive_payment.rb
@@ -19,6 +19,13 @@ class TestPaypalAdaptivePayment < MiniTest::Unit::TestCase
     assert_match /#{key}$/, url, "Could not generate the proper redirect_url_for URL"
   end
 
+  def test_redirect_pre_approval_url_for
+    assert response = @gateway.setup_purchase(fixtures(:pay_options))
+    key = response["preapprovalKey"]
+    url = @gateway.redirect_pre_approval_url_for(key)
+    assert_match /#{key}$/, url, "Could not generate the proper redirect_url_for URL"
+  end
+
   def test_successful_paydetails
     assert response = @gateway.details_for_payment(fixtures(:paydetails_options))
     assert_equal true, response.success?, "Unsuccessful Transaction"


### PR DESCRIPTION
These commits add functionality to allow a user to redirect to the correct URL when creating a pre-approval request. In addition, the setup_purchase now allows for the preapproval_key to be submitted and passed along to paypal.
