### PR TITLE
Tying to ActiveMerchant ~> 1.5.1

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use ruby-1.9.2-p290@paypal-adaptive-payment
+rvm use ruby-1.9.3@paypal-adaptive-payment

--- a/active_paypal_adaptive_payment.gemspec
+++ b/active_paypal_adaptive_payment.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("lib/**/*") + %w(MIT-LICENSE README.md CHANGELOG.md)
   s.require_path = %w(lib)
 
-  s.add_dependency(%q<activemerchant>, [">= 1.5.1"])
+  s.add_dependency(%q<activemerchant>, ["~> 1.5.1"])
   s.add_dependency(%q<multi_json>, [">= 1.0.0"])
   s.add_dependency(%q<hashie>, [">= 1.2.0"])
   s.add_dependency(%q<money>, [">= 3.6.0"])


### PR DESCRIPTION
Also, bumping the .rvmrc to Ruby 1.9.3
