### PR TITLE
Removed App ID as Required Config Variable

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
@@ -34,7 +34,7 @@ module ActiveMerchant
       self.display_name = 'Paypal Adaptive Payments'
 
       def initialize(config = {})
-        requires!(config, :login, :password, :signature, :appid)
+        requires!(config, :login, :password, :signature)
         @config = config.dup
         super
       end


### PR DESCRIPTION
Hello. Not sure why but PayPal hasn't given me an App ID - I'm not sure if they stopped altogether or what. I removed appid as a required config variable and things have been working well. Tiny change!
