### PR TITLE
Just removed that smelly code.

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payments/ext.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payments/ext.rb
@@ -28,15 +28,3 @@ module Hashie
 
   end
 end
-
-module Net
-  module HTTPHeader
-    def []= key, val
-      unless val
-        @header.delete key
-        return val
-      end
-      @header[key] = [val]
-    end
-  end
-end


### PR DESCRIPTION
I've tesed it on a sandbox - seems like PAYPAL doesn't care about headers case. Just like RFC says it should.
