### PR TITLE
Also allow details_for_payment to find a transaction by transaction_id.

### DIFF
--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
@@ -160,7 +160,11 @@ module ActiveMerchant
             x.detailLevel 'ReturnAll'
             x.errorLanguage opts[:error_language] ||= 'en_US'
           end
-          x.payKey opts[:pay_key]
+          if opts[:pay_key].present?
+            x.payKey opts[:pay_key]
+          elsif opts[:transaction_id].present?
+            x.payKey opts[:transaction_id]
+          end
         end
       end
 


### PR DESCRIPTION
The current version throws the following error message if you attempt to lookup a transaction using a `transaction_id` instead of a `pay_key`.

```
Invalid request parameter: payKey with value " parameter=["payKey", ""]
```

Note that payKey expires after 3 hours according to the Paypal [documentation](https://cms.paypal.com/us/cgi-bin/?cmd=_render-content&content_ID=developer/e_howto_api_APPaymentDetails).
