### PR TITLE
Support to add a shipping address to payment options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ Gemfile.lock
 *.gem
 TAGS
 diagram.txt
+.bundle
+vendor

--- a/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
+++ b/lib/active_merchant/billing/gateways/paypal_adaptive_payment.rb
@@ -210,6 +210,17 @@ module ActiveMerchant
             x.sharePhoneNumber opts[:sender][:share_phone_number] if opts[:sender][:share_phone_number]
             x.requireShippingAddressSelection opts[:sender][:require_shipping_address_selection] if opts[:sender][:require_shipping_address_selection]
             x.referrerCode opts[:sender][:referrerCode] if opts[:sender][:referrerCode]
+            if opts[:sender][:shipping_address]
+              x.shippingAddress do |x|
+                x.addresseeName opts[:sender][:shipping_address][:name] if opts[:sender][:shipping_address][:name]
+                x.street1 opts[:sender][:shipping_address][:street1] if opts[:sender][:shipping_address][:street1]
+                x.street2 opts[:sender][:shipping_address][:street2] if opts[:sender][:shipping_address][:street2]
+                x.city opts[:sender][:shipping_address][:city] if opts[:sender][:shipping_address][:city]
+                x.state opts[:sender][:shipping_address][:state] if opts[:sender][:shipping_address][:state]
+                x.zip opts[:sender][:shipping_address][:zip] if opts[:sender][:shipping_address][:zip]
+                x.country opts[:sender][:shipping_address][:country] if opts[:sender][:shipping_address][:country]
+              end
+            end
           end
           unless opts[:display_options].blank?
             x.displayOptions do |x|

--- a/test/fixtures.example.yml
+++ b/test/fixtures.example.yml
@@ -6,6 +6,15 @@ credentials:
 
 paydetails_options:
   pay_key: AP-49N53304XXkjh2374P
+  :sender:
+    :shipping_address:
+      :name: John
+      :street1: 17 Magneson St
+      :street2: building 1
+      :city: San Jose
+      :state: CA
+      :zip: 12345
+      :country: US
 
 recipients: &recipients
   - :email:  seller_1313041935_biz@gmail.com
@@ -19,12 +28,3 @@ pay_options:
   :return_url:  http://example.com/return
   :cancel_url: http://example.com/cancel
   :receiver_list: *recipients
-  :sender_options:
-    :shipping_address:
-      :name: John
-      :street1: 17 Magneson St
-      :street2: building 1
-      :city: San Jose
-      :state: CA
-      :zip: 12345
-      :country: US

--- a/test/fixtures.example.yml
+++ b/test/fixtures.example.yml
@@ -19,3 +19,12 @@ pay_options:
   :return_url:  http://example.com/return
   :cancel_url: http://example.com/cancel
   :receiver_list: *recipients
+  :sender_options:
+    :shipping_address:
+      :name: John
+      :street1: 17 Magneson St
+      :street2: building 1
+      :city: San Jose
+      :state: CA
+      :zip: 12345
+      :country: US


### PR DESCRIPTION
You can now add shipping address information with the payment option call.
This is handy when your checkout already collects the shipping information, when you give this to paypal the buyer protection kicks in.
